### PR TITLE
Tuner implementation for merging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,4 @@ nbdist/
 
 # virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
 hs_err_pid*
+/channels/*

--- a/src/nl/tue/ooad/EntertainmentSystem.java
+++ b/src/nl/tue/ooad/EntertainmentSystem.java
@@ -26,6 +26,8 @@ public class EntertainmentSystem extends javax.swing.JFrame {
         recorder = new Recorder(recorderPanel);
         tuner = new Tuner(tunerPanel, programGuidePanel);
         display = new Display(displayPanel);
+        
+        new Thread(tuner).start();
     }
 
     /**

--- a/src/nl/tue/ooad/Tuner.java
+++ b/src/nl/tue/ooad/Tuner.java
@@ -5,23 +5,102 @@
  */
 package nl.tue.ooad;
 
+import java.io.File;
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.LinkedBlockingDeque;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import javax.sound.sampled.AudioInputStream;
+import javax.sound.sampled.AudioSystem;
+import javax.sound.sampled.UnsupportedAudioFileException;
 import javax.swing.JPanel;
 
 /**
  *
  * @author s132054
  */
-public class Tuner implements FrameProducer {
+public class Tuner implements FrameProducer, Runnable{
     
     int channel;
     ProgramGuide guide;
     JPanel tunerPanel;
+    
+    BlockingQueue<StreamFrame> buffer;
+    
+    Map<Integer, File[]> channels;
+    ChannelIterator currentChannelIterator;
+    
+    AudioInputStream fileInput;
 
     public Tuner(JPanel tunerPanel, JPanel programGuidePanel) {
         this.tunerPanel = tunerPanel;
         guide = new ProgramGuide(programGuidePanel);
+        buffer = new LinkedBlockingDeque<>();
+        
+        // build list of channel source files based on directory structure
+        channels = new HashMap<>();
+        File[] channelDirectories = new File("./channels/").listFiles(File::isDirectory);
+        for (File f : channelDirectories) {
+            int channelNumber = Integer.parseInt(f.getName());
+            File[] sourceFiles = f.listFiles();
+            Arrays.sort(sourceFiles, (File o1, File o2) -> o1.getName().compareTo(o2.getName()));
+            channels.put(channelNumber, sourceFiles);
+            System.out.println("Channel " + channelNumber + " found");
+            for (File sf: sourceFiles) {
+                System.out.println("Program " + sf.getName() + " found");
+            }
+        }
     }
-    
+
+    @Override
+    public BlockingQueue<StreamFrame> getStreamQueue() {
+        return buffer;
+    }
+
+    @Override
+    public void run() {
+        // set channel at the start (lowest channel)?
+        int lowestChannel = channels.keySet().stream().reduce(Integer.MAX_VALUE, (t, u) -> Math.min(t, u));
+        setChannel(lowestChannel);
+        
+        // continuously fill buffer with stream frames from fileInput
+        
+        while (!Thread.interrupted()) {
+            int lastChannel = channel;
+            
+            try {
+                try {
+                    File nextInputFile = currentChannelIterator.next();
+                    System.out.println("Opening program " + nextInputFile.getName() + " on channel " + channel);
+                    System.out.println("Buffer size: " + buffer.size());
+                    fileInput = AudioSystem.getAudioInputStream(nextInputFile);
+                } catch (UnsupportedAudioFileException ex) {
+                    System.err.println("Invalid audio file at channel " + channel);
+                    ex.printStackTrace();
+                }
+
+                int frameLength = fileInput.getFormat().getFrameSize();
+                byte[] fileBuffer = new byte[frameLength];
+                while (channel == lastChannel && fileInput.available() > frameLength) {
+                    fileInput.read(fileBuffer);
+                    StreamFrame sf = new StreamFrame(Arrays.copyOf(fileBuffer, frameLength));
+                    buffer.add(sf);
+                }
+                // do not care about left-over bytes? 
+                // (either less than one frame, or switching to other channel)
+                fileInput.close();
+                
+            } catch (IOException ex) {
+                System.err.println("IO error while reading file from channel " + channel);
+                ex.printStackTrace();
+            }
+        }
+    }
     
     
     ProgramGuide getProgramGuide() {
@@ -29,11 +108,36 @@ public class Tuner implements FrameProducer {
     }
     
     void setChannel(int channel) {
-        
+        this.channel = channel;
+        currentChannelIterator = new ChannelIterator(channels.get(channel));
     }
 
     @Override
     public StreamFrame produceStream() {
         throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+    }
+    
+    class ChannelIterator implements Iterator<File> {
+        
+        int next = 0;
+        File[] channelFiles;
+
+        public ChannelIterator(File[] channelFiles) {
+            this.channelFiles = channelFiles;
+        }
+
+        @Override
+        public boolean hasNext() {
+            return true;
+        }
+
+        @Override
+        public File next() {
+            File nextFile = channelFiles[next];
+            next++;
+            next %= channelFiles.length;
+            return nextFile;
+        }
+        
     }
 }


### PR DESCRIPTION
- Only streams currently selected channel programs 
  - ¿ "time" does not progress in other channels... issue when planning recording from other channel!
  - ¡ possible solution to only allow planning of recordings in current channel
  - ¡ _or_ stream all channels simultaneously
    - ¿ but then the central notion of time needs to be synced between recorder and tuner, _or_ the recorder needs to get notified of the current program being played on each channel.
- Tuner is started in main class. 
  - starts putting bytes from lowest channel number in buffer
- loads files in ./channels/<channel_nr>/* for <channel_nr> channel
- goes over files alphabetically
- loops over files indefinitely; 
  - ¿ loading is a lot faster than playing, might need queue maximum 
    capacity, including handling when queue is full (blocking operations)

also ignoring all contents of ./channels/* to avoid committing of binaries